### PR TITLE
fix(docs): exclude the config/ data tree from API stubs and docs crawl

### DIFF
--- a/properdocs.yml
+++ b/properdocs.yml
@@ -74,6 +74,9 @@ plugins:
         - .changelog/**
         - .agents/**
         - .chezmoiroot
+        - src/personal_os_setup/config/**
+        - AGENTS.md
+        - CLAUDE.md
         - docs/examples/data/sample.*
 
 markdown_extensions:

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -61,6 +61,7 @@ plugins:
       glob:
         - node_modules/**
         - .venv/**
+        - venv/**
         - docker_data/**
         - dist/**
         - reports/**

--- a/scripts/gen_doc_stubs.py
+++ b/scripts/gen_doc_stubs.py
@@ -8,21 +8,27 @@ from pathlib import Path
 import mkdocs_gen_files
 
 src_root = Path("src")
+config_root = src_root / "personal_os_setup" / "config"
 nav = mkdocs_gen_files.Nav()
 
 for path in sorted(src_root.glob("**/*.py")):
     if "__init__" in str(path):
         print("Skipping", path)
         continue
+    # Only the importable package is API. The config/ tree is data
+    # (chezmoi dotfiles, vendored skills with their own .py code under
+    # dash-named dirs that are not valid modules) — never stub it.
+    if config_root in path.parents:
+        print("Skipping", path)
+        continue
     doc_path = Path("package", path.relative_to(src_root)).with_suffix(".md")
 
-    if "seqly" not in str(path):
-        with mkdocs_gen_files.open(doc_path, "w") as f:
-            ident = ".".join(path.relative_to(src_root).with_suffix("").parts)
-            print("::: " + ident, file=f)
-        nav[path.relative_to(src_root).with_suffix("").parts] = (
-            path.relative_to(src_root).with_suffix(".md").as_posix()
-        )
+    with mkdocs_gen_files.open(doc_path, "w") as f:
+        ident = ".".join(path.relative_to(src_root).with_suffix("").parts)
+        print("::: " + ident, file=f)
+    nav[path.relative_to(src_root).with_suffix("").parts] = (
+        path.relative_to(src_root).with_suffix(".md").as_posix()
+    )
 
 with mkdocs_gen_files.open("package/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/scripts/gen_doc_stubs.py
+++ b/scripts/gen_doc_stubs.py
@@ -15,9 +15,7 @@ for path in sorted(src_root.glob("**/*.py")):
     if "__init__" in str(path):
         print("Skipping", path)
         continue
-    # Only the importable package is API. The config/ tree is data
-    # (chezmoi dotfiles, vendored skills with their own .py code under
-    # dash-named dirs that are not valid modules) — never stub it.
+    # Only the importable package is API.
     if config_root in path.parents:
         print("Skipping", path)
         continue


### PR DESCRIPTION
## Problem

Docs deploy ([🚀 Release — Main] run 34162793550) fails after #103 merged vendored skills into `src/personal_os_setup/config/chezmoi/`:

```
ERROR - mkdocstrings: personal_os_setup.config.chezmoi.dot_claude.skills.skill-creator.eval-viewer.generate_review could not be found
ERROR - Could not collect '...generate_review'
Aborted with a BuildError!
make: *** [makefiles/build.mk:17: deploy-doc-gh] Error 1
```

`gen_doc_stubs.py` walks `src/**/*.py` and stubs every module for mkdocstrings — but the vendored skill-creator ships its own `.py` under `config/chezmoi` in dash-named dirs (`skill-creator`, `eval-viewer`) that are not valid Python modules. 10 such files → collect fails → build aborts.

## Fix

- `scripts/gen_doc_stubs.py`: skip the `config/` tree entirely — it is package **data** (chezmoi dotfiles, vendored skills), not API. Drops the now-dead `seqly` special case in favour of this generic rule.
- `properdocs.yml`: exclude `src/personal_os_setup/config/**`, `AGENTS.md`, `CLAUDE.md`, and local `venv/**` from the crawl so agent/vendored files never surface on the docs site.

## Verification

Local repro (Python 3.14.7, `properdocs build`): before → identical BuildError; after → **Documentation built in 11.24 seconds**, zero ERRORs, skill/vendored orphans gone from the nav warnings.