### PR TITLE
feat(skills): add make skills-deploy target

### DIFF
--- a/makefiles/skills.mk
+++ b/makefiles/skills.mk
@@ -2,10 +2,14 @@
 # Canonical skills live in .claude/skills; .agents/skills holds git symlinks so
 # non-Claude agents (Hermes, Codex, OpenCode, skills CLI) see the same files.
 
-.PHONY: skills-link skills-check
+.PHONY: skills-link skills-check skills-deploy
 
 CLAUDE_SKILLS := .claude/skills
 AGENTS_SKILLS := .agents/skills
+
+# Global deploy: the chezmoi source doubles as the container/CLI deploy source.
+SKILLS_SRC := src/personal_os_setup/config/chezmoi/dot_claude/skills
+SKILLS_DST := $(HOME)/.claude/skills
 
 skills-link: ## Create/refresh .agents/skills symlinks -> .claude/skills
 	@mkdir -p $(AGENTS_SKILLS)
@@ -34,3 +38,8 @@ skills-check: ## Verify every .claude/skills skill has a working .agents/skills 
 		[ -e "$$l" ] && continue; \
 		echo "STALE $$l  (run: make skills-link)"; rc=1; \
 	done; exit $$rc
+
+skills-deploy: ## Copy shared skills from the chezmoi source to ~/.claude/skills (both agents read this dir)
+	@mkdir -p $(SKILLS_DST)
+	@cp -R $(SKILLS_SRC)/. $(SKILLS_DST)/
+	@echo "deployed shared skills to $(SKILLS_DST)"

--- a/src/personal_os_setup/config/chezmoi/dot_claude/skills/skill-deployment/SKILL.md
+++ b/src/personal_os_setup/config/chezmoi/dot_claude/skills/skill-deployment/SKILL.md
@@ -18,6 +18,10 @@ REPO=/config/workspace/personal-os-setup
 cd ~ && chezmoi apply -v --force --source "$REPO" .claude    # deploy ONLY the skills
 ```
 
+**No chezmoi (HA container/CLI):** `cd <repo> && make skills-deploy` — copies the same source
+to `~/.claude/skills`. The make target lives in `makefiles/skills.mk` (same file as
+`skills-link`/`skills-check`).
+
 Two gotchas (both previously caused "not managed"):
 1. `--source` = repo **ROOT** (git-backed, `.chezmoiroot` points at the nested dir) — never the nested dir
 2. Run from **HOME** — targets resolve against CWD


### PR DESCRIPTION
One-command container/CLI refresh of the shared skills: copies the chezmoi source (`src/personal_os_setup/config/chezmoi/dot_claude/skills/`) to `~/.claude/skills` — the dir both agents read (Claude Code via HOME, Hermes via external_dirs).

- No chezmoi binary needed (containers don't have it)
- Replaces the manual `cp` refresh; `skills-deploy` joins `skills-link`/`skills-check` in skills.mk
- skill-deployment doc updated with the no-chezmoi path

Verified live in the HA container: `make skills-deploy HOME=/config` → deploy + diff against source = identical.